### PR TITLE
Add Docker Compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ Configure the database so that the user `bitcoin` can access `lndmanagej` withou
 
 Install Java 21 and run `./start.sh`.
 
+### Using Docker Compose
+You can start lnd-manageJ together with a PostgreSQL database using Docker Compose.
+Run the following command in the repository root to build the image and start both services:
+
+```bash
+docker compose up --build
+```
+
+The application listens on port `8081`.  Adjust the volume mounts in
+`docker-compose.yml` so that the container can access your lnd data and
+`lnd-manageJ.conf` file.
+
 ## Disclaimer
 This project is not related to bitromortac's Python based [lndmanage](https://github.com/bitromortac/lndmanage).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: lndmanagej
+      POSTGRES_USER: bitcoin
+      POSTGRES_PASSWORD: unset
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+  lnd-managej:
+    build: .
+    command: java -jar application/build/libs/application-boot.jar --spring.config.location=classpath:application.properties,/root/override.properties
+    depends_on:
+      - db
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/lndmanagej
+      SPRING_DATASOURCE_USERNAME: bitcoin
+      SPRING_DATASOURCE_PASSWORD: unset
+    ports:
+      - "8081:8081"
+    volumes:
+      - ~/.lnd:/root/.lnd:ro
+      - ~/.config/lnd-manageJ.conf:/root/.config/lnd-manageJ.conf:ro
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with postgres and lnd-manageJ services
- document how to start the stack in the README

## Testing
- `./gradlew test -x integrationTest --no-daemon` *(fails: GC daemon issues)*

------
https://chatgpt.com/codex/tasks/task_e_6841a31f7030832da0533618c9c39e95