### PR TITLE
Fix docker host instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,15 @@ docker compose up --build
 The application listens on port `8081`.  Adjust the volume mounts in
 `docker-compose.yml` so that the container can access your lnd data and
 `lnd-manageJ.conf` file.
+If lnd is running on the host machine, add the following to the
+`lnd-managej` service in `docker-compose.yml`:
+
+```yaml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
+and set `host=host.docker.internal` in the `[lnd]` section of your
+`lnd-manageJ.conf` file so that lnd-manageJ can reach lnd on the host.
 
 ## Disclaimer
 This project is not related to bitromortac's Python based [lndmanage](https://github.com/bitromortac/lndmanage).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,5 +23,7 @@ services:
     volumes:
       - ~/.lnd:/root/.lnd:ro
       - ~/.config/lnd-manageJ.conf:/root/.config/lnd-manageJ.conf:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 volumes:
   postgres-data:

--- a/example-lnd-manageJ.conf
+++ b/example-lnd-manageJ.conf
@@ -4,6 +4,7 @@
 # If in doubt, remove any configuration option you do not fully understand!
 
 [lnd]
+# use host.docker.internal if lnd-manageJ runs in Docker and lnd runs on the host
 host=localhost
 port=10009
 macaroon_file=/home/user/.lnd/data/chain/bitcoin/mainnet/admin.macaroon


### PR DESCRIPTION
## Summary
- mention host gateway in README and example config
- add host gateway mapping in docker compose

## Testing
- `./gradlew test --no-daemon` *(fails: Gradle build not completed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6841bed579a0832dadcbd9bc8e6a5524